### PR TITLE
Support for ES7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+**This branch is not intended to merge**, but rather, to be referenced in by gemfiles for apps
+needing support for ElasticSearch 7.
+
+When chewy officially supports ElasticSearch 7 and publishes a gem version supporting it, this fork
+should be removed and apps should switch back to the chewy gem.
+
+
+--------------------------------
+
+
 [![Gem Version](https://badge.fury.io/rb/chewy.svg)](http://badge.fury.io/rb/chewy)
 [![Build Status](https://travis-ci.org/toptal/chewy.svg)](https://travis-ci.org/toptal/chewy)
 [![Code Climate](https://codeclimate.com/github/toptal/chewy.svg)](https://codeclimate.com/github/toptal/chewy)

--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec| # rubocop:disable BlockLength
   spec.add_development_dependency 'unparser'
 
   spec.add_dependency 'activesupport', '>= 4.0'
-  spec.add_dependency 'elasticsearch', '>= 2.0.0'
+  spec.add_dependency 'elasticsearch', '>= 7.0.0'
   spec.add_dependency 'elasticsearch-dsl'
 end

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -59,7 +59,7 @@ module Chewy
 
           body = specification_hash
           body[:aliases] = {general_name => {}} if options[:alias] && suffixed_name != general_name
-          result = client.indices.create(index: suffixed_name, body: body)
+          result = client.indices.create(index: suffixed_name, body: body, include_type_name: true)
 
           Chewy.wait_for_status if result
           result

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -1101,7 +1101,8 @@ module Chewy
         index: _indexes.one? ? _indexes.first : _indexes,
         type: _types.one? ? _types.first : _types do
         begin
-          Chewy.client.search(_request)
+          request = _request.merge(rest_total_hits_as_int: true)
+          Chewy.client.search(request)
         rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
           raise e if e.message !~ /IndexMissingException/ && e.message !~ /index_not_found_exception/
           {}

--- a/lib/chewy/search.rb
+++ b/lib/chewy/search.rb
@@ -58,7 +58,7 @@ module Chewy
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html
       # @return [Hash] the request result
       def search_string(query, options = {})
-        options = options.merge(all.render.slice(:index, :type).merge(q: query))
+        options = options.merge(all.render.slice(:index, :type).merge(q: query)).merge(rest_total_hits_as_int: true)
         Chewy.client.search(options)
       end
 

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -978,6 +978,7 @@ module Chewy
         ActiveSupport::Notifications.instrument 'search_query.chewy',
           notification_payload(request: request_body) do
             begin
+              request_body = request_body.merge(rest_total_hits_as_int: true)
               Chewy.client.search(request_body)
             rescue Elasticsearch::Transport::Transport::Errors::NotFound
               {}

--- a/lib/chewy/type/syncer.rb
+++ b/lib/chewy/type/syncer.rb
@@ -207,7 +207,8 @@ module Chewy
 
         mappings = @type.client.indices.get_mapping(
           index: @type.index_name,
-          type: @type.type_name
+          type: @type.type_name,
+          include_type_name: true
         ).values.first.fetch('mappings', {})
 
         @outdated_sync_field_type = mappings


### PR DESCRIPTION
**This PR not intended to merge**, but rather, the branch is intended to be referenced in by gemfiles and the PR is intended to describe the temporary use of a forked repo in place of the official chewy gem. 

When chewy officially supports ElasticSearch 7 and publishes a gem version supporting it, this fork should be removed and apps should switch back to the chewy gem. 

Changes were borrowed from https://github.com/noellabo/chewy/commit/94e8a6cfc540e06c051d1217e13dda0d73442e8b